### PR TITLE
 minor edit

### DIFF
--- a/lib/HackaMol/MolReadRole.pm
+++ b/lib/HackaMol/MolReadRole.pm
@@ -6,6 +6,7 @@ use Carp;
 use Math::Vector::Real;
 use HackaMol::PeriodicTable qw(%KNOWN_NAMES);
 use FileHandle;
+use HackaMol::Atom;#add the code,the Role may better to understand
 
 has 'hush_read' => (
     is      => 'rw',

--- a/lib/HackaMol/MolReadRole.pm
+++ b/lib/HackaMol/MolReadRole.pm
@@ -303,7 +303,7 @@ sub read_xyz_atoms {
 sub _trim {
     my $string = shift;
     $string =~ s/^\s+//;
-    $string =~ s/\s+$//;
+ #   $string =~ s/\s+$//; #unpack will delete the \s+ in the end;
     return $string;
 }
 


### PR DESCRIPTION
unpack will delete the \s+ in the end;
so it need't to replace.